### PR TITLE
Numba sampler list to tuple.

### DIFF
--- a/six_images_numba.py
+++ b/six_images_numba.py
@@ -154,7 +154,7 @@ def sample_coor_cuda(
     d_offsets     = cuda.to_device(offsets)
 
     cuda.synchronize()
-    k_sample_coor[[1024,1,1],[256,1,1]]( d_output, d_out_offsets, d_xyz, d_offsets )
+    k_sample_coor[(1024,1,1),(256,1,1)]( d_output, d_out_offsets, d_xyz, d_offsets )
     cuda.synchronize()
 
     output = d_output.copy_to_host()


### PR DESCRIPTION
Thank you for putting so much effort into this Yaoyu!

The `numba` sampler threw an error for me, complaining about `k_sample_coor[[1024,1,1],[256,1,1]]( d_output, d_out_offsets, d_xyz, d_offsets )` that

```
TypeError: unhashable type: 'list'
```

Changing the inner lists to a tuple seemed to have done the trick for me. Could you please try it out to make sure it does not break anything else?